### PR TITLE
Remove InsecureRequestWarning

### DIFF
--- a/freesms/__init__.py
+++ b/freesms/__init__.py
@@ -9,6 +9,7 @@ See:
 """
 
 import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 __version__ = '0.1.1'
 
@@ -75,7 +76,7 @@ class FreeClient(object):
 
         if not kw["verify"]:
             # remove SSL warning
-            requests.packages.urllib3.disable_warnings()
+            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
         res = requests.get(FreeClient.BASE_URL, params=params, **kw)
         return FreeResponse(res.status_code)


### PR DESCRIPTION
Type of message removed:
/usr/lib/python3/dist-packages/urllib3/connectionpool.py:794: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)