### PR TITLE
Update license string setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email='b@ptistefontaine.fr',
     packages=['freesms'],
     url='https://github.com/bfontaine/freesms',
-    license=io.open('LICENSE', encoding='utf-8').read().encode("utf-8"),
+    license="MIT",
     description='Send SMS with Free Mobile',
     install_requires=["requests"],
     long_description="""\


### PR DESCRIPTION
The `license` field in `setup.py` should just be the used license.
https://docs.python.org/3/distutils/setupscript.html#additional-meta-data

Alternatively, although not preferred, it can also be the full license text, but encoded as a string.
https://packaging.python.org/specifications/core-metadata/#license

Currently, the license is of type `bytes` which will cause a `setuptools` error when installing `freesms` from the source distribution.